### PR TITLE
Feat/creator address

### DIFF
--- a/backend/src/controllers/v1/challenges.ts
+++ b/backend/src/controllers/v1/challenges.ts
@@ -35,12 +35,12 @@ export class ChallengesController {
     };
 
     public create: RequestHandler = async (req, res) => {
-        //const user = await AuthService.find((req as any).auth?.sub);
+        const user = await AuthService.find((req as any).auth?.sub);
         //TODO: add back auth (it did not work)
         try {
             const challenge = await ChallengesService.create(
-                req.body
-                //user.id
+                req.body,
+                user.id
             );
 
             if (!challenge) {

--- a/backend/src/controllers/v1/challenges.ts
+++ b/backend/src/controllers/v1/challenges.ts
@@ -36,7 +36,6 @@ export class ChallengesController {
 
     public create: RequestHandler = async (req, res) => {
         const user = await AuthService.find((req as any).auth?.sub);
-        //TODO: add back auth (it did not work)
         try {
             const challenge = await ChallengesService.create(
                 req.body,
@@ -48,6 +47,7 @@ export class ChallengesController {
             }
             res.status(200).send(challenge);
         } catch (err: any) {
+            console.log(err, 'wats err?')
             res.status(500).send({ error: err.message });
         }
     }

--- a/backend/src/data/migrations/20231103005059_create_table_groups.ts
+++ b/backend/src/data/migrations/20231103005059_create_table_groups.ts
@@ -7,6 +7,8 @@ export async function up(knex: Knex): Promise<void> {
         table.string('name').notNullable();
         table.string('description').nullable();
         table.string('publicAddress').nullable().unique();
+        table.string('nonceKey').nullable();
+        table.string('AAWalletAddress').nullable().unique();
         table.integer('mintCount').defaultTo(0).notNullable(); //increment this value after someone has minted to/thorugh group 
         table.integer('wonChallenges').defaultTo(0).notNullable(); //increment this value after the group has been set as Top Contributor
         table.integer('totalRewardedInEth').defaultTo(0).notNullable(); //NOT SURE BUT: increment this value after listening to withdrawalReward()→ emits an event (participant: userWhoGetTheReward, amount), this is related to a poolAddress and that pool has an assosciated groupAddress that I can get?

--- a/backend/src/data/migrations/20231103005205_create_table_challenges.ts
+++ b/backend/src/data/migrations/20231103005205_create_table_challenges.ts
@@ -19,7 +19,8 @@ export async function up(knex: Knex): Promise<void> {
         table.timestamp("expiration").nullable(); //example: 7 days from creation //expiration: new Date("2023-12-01T12:00:00Z")
         table.integer("totalMints").nullable()
         table.boolean("expired").nullable();
-        table.unique(["tokenId", "mintingContractAddress", "creatorOfMint"])
+        table.string("honeyPotAddress").nullable()
+        table.unique(["tokenId", "mintingContractAddress", "creatorOfMint", "chainId"])
         table.timestamps({ useCamelCase: true });
     });
 }

--- a/backend/src/data/seeds/dev/1_user-groups-challenges.ts
+++ b/backend/src/data/seeds/dev/1_user-groups-challenges.ts
@@ -34,76 +34,100 @@ export async function seed(knex: Knex): Promise<void> {
 
 
     await trx("challenges").insert([
-
-
       {
-        name: "Gitcoin Impact Report 01: PDF Onchain",
-        mintingContractAddress: "0x81D226fb36cA785583E79E84312335d0e166D59B",
-        creatorOfMint: "gitcoin.eth",
-        chainId: "777777",
-        tokenId: "1",
-        imageUrl: "ipfs://bafybeieopdawoakmvioeyutkgogc34npcxwzuv2eo3pyconpkbs2ygobtu",
-        category: "art",
-        platform: "zora",
-        expiration: "2030-06-06 13:59:08.053-03",
-        totalMints: "2",
-      },
-
-      {
-        name: "Sonic Zorb",
-        mintingContractAddress: "0xb3d0bA3c295FdB0918Fe4BcDE04f62f36E60F50c",
-        creatorOfMint: "amy.eth",
-        chainId: "777777",
-        tokenId: "0",
-        imageUrl: "ipfs://QmTPUXc8Kh2NEA6M4B4mKDqxs5dRK5oVuwCj8iyBFtyHcW/0.png",
-        category: "art",
-        platform: "zora",
-        expiration: "2024-07-01 13:59:49.831-03",
-        totalMints: "13",
-      },
-
-      {
-        mintingContractAddress: '0xBD87f4dA73ff92A7BeA31e2dE20E14f9829f42Fe',
-        chainId: 8453,
-        tokenId: null,
-        category: 'music',
-        name: 'Keepers Of Wisdom',
-        platform: null,
-        expiration: "2024-02-13T21:41:36.090Z",
-        expired: null,
-        totalMints: 10,
-        imageUrl: 'https://img.reservoir.tools/images/v2/base/hc%2BnPcLmWxs%2FDW99DlBQ42k40ZoyYV5jCIms5qHjwvuiiod1GIdCBqGsYCdDMem3ilRBzFP%2BrZrV8f92sO2zb1bE7la8NyJUSf2FHzsOwXDyehGVJtjY04yxEDVnKrnlLnLKCDLNSZiPiqDzBabHZfq636Dwjry3EPfzqmjrtEbdSsTTr69sJG6KieVpgAmG?width=512',
-        creatorOfMint: '0x625307de45bd25ad6bf6cc7391a308fc84067cf7'
-      },
-
-      {
-        mintingContractAddress: '0x9F3303E2C04e79387C3B5089B8a73e0B466e9076',
+        id: "13c7d5d7-05f4-435f-87c7-126ff26f2f21",
+        mintingContractAddress: "0xfcf069b5876ab35107e44906933cf67110a60bcd",
         chainId: 10,
         tokenId: null,
-        category: 'music',
-        name: 'Pete Rango - HONEY ft Betty Dawl',
-        platform: null,
-        expiration: "2024-02-10T21:46:09.910Z",
+        category: "music",
+        name: "Karma.wav - BREATHE",
+        kind: "erc721",
+        floorPrice: "0.00078",
+        expiration: "2023-12-17T15:29:09.644Z",
         expired: null,
-        totalMints: 101,
-        imageUrl: 'https://img.reservoir.tools/images/v2/optimism/ldXga3w5LnmrtU6KljLWfUlu8HfaO8ITP6Qa1%2ByIa3wZjvpQ0%2FenYI8QxnThWpoVEiuLQARDLoZoOIU7SV2dFUKLqNlwJoaRXRnYgyjR%2BwUiKG7opbVx29UD8bN3Fu9PU3w8ALcBo5s0kbc1mGIyh7kYgtIIaSSHSDDnSLDmqdqLf%2Fqny4x6LLTJzSnyuzjv',
-        creatorOfMint: "peterango.eth"
+        totalMints: 28,
+        imageUrl: "https://img.reservoir.tools/images/v2/optimism/ldXga3w5LnmrtU6KljLWfUlu8HfaO8ITP6Qa1%2ByIa3wZjvpQ0%2FenYI8QxnThWpoV%2Fw8JlZ3tNvKq8fesoPtKUnUZGQTsl6%2FJMXBwe2Zkc8YZ6t2tXlSakl4GsvSs4MB0cOsOyHPULZwHPCK1CRH6hTeUgGP4AE%2FYu4oDeq9lyE5dinGGdd3lj3lqqwv7D6YF",
+        network: "optimism",
+        creatorOfMint: "0xe7910F0b83ad155737043c771E2594f74B0BB739",
+        honeyPotAddress: "honey0xfcf069b5876ab35107e44906933cf67110a60bcd",
+
       },
-
       {
-        mintingContractAddress: '0xbc2ca61440faf65a9868295efa5d5d87c55b9529',
-        chainId: 7777777,
+        id: "0a3bff0b-2e41-4535-b14b-23cff27419c6",
+        mintingContractAddress: "0x9f3303e2c04e79387c3b5089b8a73e0b466e9076",
+        chainId: 10,
         tokenId: null,
-        category: 'art',
-        name: 'sqr(16)',
-        platform: null,
-        expiration: "2023-12-12T21:59:02.806Z",
+        category: "music",
+        name: "Pete Rango - HONEY ft Betty Dawl",
+        kind: "erc721",
+        floorPrice: "0.00078",
+        expiration: "2023-12-19T15:29:46.688Z",
         expired: null,
-        totalMints: 515200,
-        imageUrl: 'https://img.reservoir.tools/images/v2/zora/hc%2BnPcLmWxs%2FDW99DlBQ42k40ZoyYV5jCIms5qHjwvtE2G7JSZ5NiF4xU%2F0kOsOnXSdFDdpd3qZtJdJ0HSfrgiQOQzuJ8CsbfqCqED1URzXTKjhi7mLwPZVQY3FJE7FOfBXNSJ8gHYSiLGPPhE%2BuJMv%2BWFQBzaigZ4PI6TnAdmC7Ev1T0p%2FD%2BL%2BnQCM7WHvl',
-        creatorOfMint: '0xdbe0c5341a229e604ef99093972f5e30984f95ac'
-      }
+        totalMints: 102,
+        imageUrl: "https://img.reservoir.tools/images/v2/optimism/ldXga3w5LnmrtU6KljLWfUlu8HfaO8ITP6Qa1%2ByIa3wZjvpQ0%2FenYI8QxnThWpoVEiuLQARDLoZoOIU7SV2dFUKLqNlwJoaRXRnYgyjR%2BwUiKG7opbVx29UD8bN3Fu9PU3w8ALcBo5s0kbc1mGIyh7kYgtIIaSSHSDDnSLDmqdqLf%2Fqny4x6LLTJzSnyuzjv",
+        network: "optimism",
+        creatorOfMint: "0xe7910F0b83ad155737043c771E2594f74B0BB739",
+        honeyPotAddress: "honey0x9f3303e2c04e79387c3b5089b8a73e0b466e9076",
 
+
+      },
+      {
+        id: "53a61b1c-a008-4fff-b8a1-d4f509765891",
+        mintingContractAddress: "0xbd87f4da73ff92a7bea31e2de20e14f9829f42fe",
+        chainId: 8453,
+        tokenId: null,
+        category: "art",
+        name: "Keepers Of Wisdom",
+        kind: "erc721",
+        floorPrice: "0.00778",
+        expiration: "2023-12-19T15:30:09.425Z",
+        expired: null,
+        totalMints: 10,
+        imageUrl: "https://img.reservoir.tools/images/v2/base/hc%2BnPcLmWxs%2FDW99DlBQ42k40ZoyYV5jCIms5qHjwvuiiod1GIdCBqGsYCdDMem3ilRBzFP%2BrZrV8f92sO2zb1bE7la8NyJUSf2FHzsOwXDyehGVJtjY04yxEDVnKrnlLnLKCDLNSZiPiqDzBabHZfq636Dwjry3EPfzqmjrtEbdSsTTr69sJG6KieVpgAmG?width=512",
+        network: "base",
+        creatorOfMint: "0x625307de45bd25ad6bf6cc7391a308fc84067cf7",
+        honeyPotAddress: "honey0xbd87f4da73ff92a7bea31e2de20e14f9829f42fe",
+
+
+      },
+      {
+        id: "6aa14761-275b-4c0b-9e1a-4f2530156ba7",
+        mintingContractAddress: "0x5aa959de99e0e49b8a85e0a630a74a7b757772b7",
+        chainId: 7777777,
+        tokenId: "1",
+        category: "art",
+        name: "ThereIsNoHEAVENThereIsNoHELL",
+        kind: "erc1155",
+        floorPrice: "0.0015",
+        expiration: "2023-12-22T15:30:35.702Z",
+        expired: null,
+        totalMints: 487,
+        imageUrl: "https://img.reservoir.tools/images/v2/zora/hc%2BnPcLmWxs%2FDW99DlBQ42k40ZoyYV5jCIms5qHjwvvxzrfLu4GyGWsfcmGlU0MDMiivLAWSZu2LUywcr6DPMKZk%2B%2BH%2F7riXkaK3Iq%2BOS4mHiyxrfOdQwkwz7JSYRSo8ZCvVfirTPdS5xpBDKdL8SYQDFBH1Dv5g6vyBLFDdyEEPPPH9Kd3Bw5U%2BZr9c%2BtcE?width=512",
+        network: "zora",
+        creatorOfMint: "0xe7910F0b83ad155737043c771E2594f74B0BB",
+        honeyPotAddress: "honey0x5aa959de99e0e49b8a85e0a630a74a7b757772b7",
+
+
+      },
+      {
+        id: "b79e4d78-ffd9-4ea0-9647-1c437d2c10df",
+        mintingContractAddress: "0x6a7463c342027ee8452f2686ccfa9b73026b4095",
+        chainId: 10,
+        tokenId: "1",
+        category: "music",
+        name: "Break It - msft (Vivid Fever Dreams FLIP) - Limited #1",
+        kind: "erc721",
+        floorPrice: "0.00478",
+        expiration: "2023-12-25T15:31:05.863Z",
+        expired: null,
+        totalMints: 1,
+        imageUrl: "https://img.reservoir.tools/images/v2/optimism/ldXga3w5LnmrtU6KljLWfUlu8HfaO8ITP6Qa1%2ByIa3wZjvpQ0%2FenYI8QxnThWpoV8D2KJW6d2w8S9SwXBG2ZwD9UH%2BebUWw6q%2FrdVQWUjq0saRy3e%2BsZujPeVoK3txL1Pjo9gCNEKUyRs9Ufwp0D6Uhbe6Oo3G8SzsWz8o5DcelYUDplWh90mIQ38T7%2FWUsU?width=512",
+        network: "optimism",
+        creatorOfMint: "0xe7910F0b83ad155737043c771E2594f74B0BB739",
+        honeyPotAddress: "honey0x6a7463c342027ee8452f2686ccfa9b73026b4095",
+
+
+      }
     ]);
   });
 }

--- a/backend/src/models/challenges.ts
+++ b/backend/src/models/challenges.ts
@@ -9,6 +9,8 @@ export interface Challenge {
     platform: string
     expiration: string
     expired: boolean
+    honeyPotAddress: string;
+
 }
 
 

--- a/backend/src/routes/v1/challenges.ts
+++ b/backend/src/routes/v1/challenges.ts
@@ -4,7 +4,7 @@ import { authentication } from "../../middlewares";
 export const challengesRouter = Router();
 const challenge = new ChallengesController();
 
-challengesRouter.post("", challenge.create);
+challengesRouter.post("", authentication, challenge.create);
 challengesRouter.post("/:id", challenge.find);
 challengesRouter.get("", challenge.findAll);
 

--- a/backend/src/services/challenges.ts
+++ b/backend/src/services/challenges.ts
@@ -35,7 +35,8 @@ export class ChallengesService {
                     "totalMints",
                     "imageUrl",
                     "network",
-                    "creatorOfMint"
+                    "creatorOfMint",
+                    "honeyPotAddress"
                 ]
             );
 
@@ -69,6 +70,7 @@ export class ChallengesService {
                 "imageUrl",
                 "network",
                 "creatorOfMint",
+                "honeyPotAddress",
                 dbClient.raw('COUNT(groups.id) as groupCount')
             )
             .leftJoin("pools", "challenges.id", "pools.challengeId")

--- a/backend/src/services/challenges.ts
+++ b/backend/src/services/challenges.ts
@@ -6,6 +6,7 @@ export class ChallengesService {
 
     public static async create(
         data: any,
+        userId: string
 
     ): Promise<Challenge | null> {
         //TODO: change this to challenges data insert

--- a/backend/src/services/pools.ts
+++ b/backend/src/services/pools.ts
@@ -48,6 +48,7 @@ export class PoolsService {
           'challenges.expiration',
           'challenges.totalMints',
           'challenges.expired',
+          'challenges.honeyPotAddress',
         )
         .from('pools')
         .where('pools.groupId', '=', groupId)

--- a/backend/src/utils/reservoir-api/token-metadata.ts
+++ b/backend/src/utils/reservoir-api/token-metadata.ts
@@ -14,7 +14,6 @@ export async function fetchReservoirData(collectionAddress: string, network: str
     let _tokenId = tokenId ? tokenId : ""
     const url = getServerUrlForTokenData(_tokenId, network, collectionAddress)
     let price = await getFloorPrice(_tokenId, network, collectionAddress)
-    console.log(price, 'wats price?')
     try {
         const response = await axios.get(url, configHeaders);
         const data = response.data;

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -50,7 +50,6 @@ export const Chat = (props: ChatProps) => {
           groupId,
         };
         const postMessage = await ApiService.createMessage(message);
-        console.log(postMessage);
       } catch (error) {
         console.error("Error sending message:", error);
       }

--- a/frontend/src/hooks/Collective/useGetPoolsByGroupId.tsx
+++ b/frontend/src/hooks/Collective/useGetPoolsByGroupId.tsx
@@ -11,7 +11,6 @@ export function useGetPoolsByGroupId(groupId: string) {
         if (!pools && groupId) {
           setLoading(true);
           const _pools = await ApiService.readPoolsByGroupId(groupId);
-          console.log(_pools, "PÖÖLS?");
           setPools(_pools);
           setLoading(false);
         }

--- a/frontend/src/pages/Discover/CreateChallengeModal.tsx
+++ b/frontend/src/pages/Discover/CreateChallengeModal.tsx
@@ -43,6 +43,7 @@ const CreateGroupModal = forwardRef(function CreateGroupModal(
     category: "", //music, art or other
     network: "", // zora, arbitrum, polygon or base
     expiration: "",
+    honeyPotAddress: "",
   });
   const { mintingContractAddress, chainId, category, network, expiration } =
     createdChallenge;
@@ -91,6 +92,19 @@ const CreateGroupModal = forwardRef(function CreateGroupModal(
                 setCreatedChallenge((prevGroup) => ({
                   ...prevGroup,
                   mintingContractAddress: e.detail.value!,
+                }))
+              }
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonInput
+              label="Honey Pot Reward Contract Address"
+              label-placement="floating"
+              placeholder="Enter the address"
+              onIonInput={(e) =>
+                setCreatedChallenge((prevGroup) => ({
+                  ...prevGroup,
+                  honeyPotAddress: e.detail.value!,
                 }))
               }
             ></IonInput>

--- a/frontend/src/pages/Discover/CreateChallengeModal.tsx
+++ b/frontend/src/pages/Discover/CreateChallengeModal.tsx
@@ -65,7 +65,6 @@ const CreateGroupModal = forwardRef(function CreateGroupModal(
     }
   };
 
-  console.log(createdChallenge, "created challegne");
   return (
     <IonModal
       initialBreakpoint={0.95}

--- a/frontend/src/pages/Discover/New.tsx
+++ b/frontend/src/pages/Discover/New.tsx
@@ -84,8 +84,6 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
     );
   }, [challenges]);
 
-  console.log(groupedChallenges, "groupedChallenges");
-
   return (
     <IonPage>
       <IonContent className="ion-padding" color="light">

--- a/frontend/src/pages/Discover/New.tsx
+++ b/frontend/src/pages/Discover/New.tsx
@@ -84,6 +84,8 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
     );
   }, [challenges]);
 
+  console.log(challenges, "challenges");
+
   return (
     <IonPage>
       <IonContent className="ion-padding" color="light">

--- a/frontend/src/pages/Discover/New.tsx
+++ b/frontend/src/pages/Discover/New.tsx
@@ -15,6 +15,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import CreateGroupModal from "./CreateChallengeModal";
 import { Challenge } from "@/types/challenges";
 import ChallengeItemModal from "@/components/ChallengesModal/ChallengeItemModal";
+import { useAccount } from "wagmi";
+import { useSignInWallet } from "@/hooks/useSignInWallet";
 
 export type GroupedChallenge = {
   [key: string]: Challenge[];
@@ -25,6 +27,7 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
   const page = useRef(undefined);
   const createChallengeModal = useRef<HTMLIonModalElement>(null);
   const [itemModalIsOpen, setItemModalIsOpen] = useState(false);
+  const { user } = useSignInWallet();
 
   const [presentingElement, setPresentingElement] = useState<
     HTMLElement | undefined
@@ -70,13 +73,15 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
     } else {
       setItemModalIsOpen(false);
     }
-  }, [selectedChallenge]);
+  }, [selectedChallenge, user]);
 
   const groupedChallenges: GroupedChallenge = useMemo(() => {
-    return challenges?.reduce((rv: GroupedChallenge, x: Challenge) => {
-      (rv[x["category"]] = rv[x["category"]] || []).push(x);
-      return rv;
-    }, {}) || {};
+    return (
+      challenges?.reduce((rv: GroupedChallenge, x: Challenge) => {
+        (rv[x["category"]] = rv[x["category"]] || []).push(x);
+        return rv;
+      }, {}) || {}
+    );
   }, [challenges]);
 
   console.log(groupedChallenges, "groupedChallenges");
@@ -92,6 +97,7 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
           <IonFabButton
             id="open-create-challenge-modal"
             className="create-fab-button"
+            disabled={!user}
           >
             <IonIcon src="/assets/icons/add.svg"></IonIcon>
             <IonLabel>Create Challenge</IonLabel>
@@ -125,7 +131,11 @@ const New: React.FC<RouteComponentProps> = (routerProps) => {
 
         <ChallengeItemModal
           isOpen={itemModalIsOpen}
-          challenges={selectedChallenge ? groupedChallenges[selectedChallenge.category] : challenges || []}
+          challenges={
+            selectedChallenge
+              ? groupedChallenges[selectedChallenge.category]
+              : challenges || []
+          }
           selectedChallengeId={selectedChallenge?.id}
           presentingElement={presentingElement!}
           dismiss={onCloseChallenteItemModal}

--- a/frontend/src/types/challenges.ts
+++ b/frontend/src/types/challenges.ts
@@ -23,6 +23,7 @@ export interface Challenge {
     network: string;
     creatorOfMint: null | string;
     groupcount?: string
+    honeyPotAddress: string;
 }
 
 

--- a/frontend/src/types/general-types.ts
+++ b/frontend/src/types/general-types.ts
@@ -36,6 +36,8 @@ export type PoolWithChallenge = {
     platform: string;
     expiration: string;
     totalMints: number;
+    honeyPotAddress: string;
+
     expired: null | boolean;
 };
 


### PR DESCRIPTION
- Add honeyPotAddress to challenges table and types
- add nonceKey and Account Abstraction Wallet Address to groups table
- Added back auth for creating challenges, and creating challenges with honey pot address now works
- Added so that if the creator of the collection is not found in the token data from Reservoir NFT Api, we use the authenticated user address who creates the challenge instead